### PR TITLE
chore(r-06): add nginx TLS1.3 config + docs

### DIFF
--- a/infra/nginx/docs/infra-tls.md
+++ b/infra/nginx/docs/infra-tls.md
@@ -1,0 +1,11 @@
+# R-06: Enforce TLS 1.3 and Security Headers
+
+- All traffic forced HTTPS (301 redirect from HTTP).
+- TLS 1.3 only (TLS 1.0–1.2 disabled).
+- HSTS enabled with preload + includeSubDomains.
+- Baseline security headers: HSTS, X-Content-Type-Options, Referrer-Policy, X-Frame-Options, CSP.
+
+## Tests
+- `curl -I http://host` → 301 to https
+- `curl --tls-max 1.2 https://host` fails handshake
+- Response headers visible in `curl -I https://host`

--- a/infra/nginx/nginx.conf
+++ b/infra/nginx/nginx.conf
@@ -1,0 +1,15 @@
+server { listen 80; return 301 https://$host$request_uri; }
+server {
+  listen 443 ssl http2;
+  ssl_certificate     /etc/ssl/fullchain.pem;
+  ssl_certificate_key /etc/ssl/privkey.pem;
+  ssl_protocols TLSv1.3;
+
+  add_header Strict-Transport-Security "max-age=63072000; includeSubDomains; preload" always;
+  add_header X-Content-Type-Options "nosniff" always;
+  add_header Referrer-Policy "no-referrer" always;
+  add_header X-Frame-Options "DENY" always;
+  add_header Content-Security-Policy "default-src 'self'; object-src 'none'; base-uri 'none'";
+
+  location / { proxy_pass http://app:8080; }
+}


### PR DESCRIPTION
## Summary
Added initial TLS1.3-only Nginx config with HSTS and baseline security headers.  
Added infra-tls.md with test instructions.

## Demo Steps
- curl -I http://host → 301 to https  
- curl --tls-max 1.2 https://host → fails  
- curl -I https://host → headers visible  

Closes #<SR-06 issue number 4>

